### PR TITLE
Install whenever gem and set rake to execute every hour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 7.1.3", ">= 7.1.3.2"
 # Use sqlite3 as the database for Active Record
 gem "pg"
 gem 'dotenv-rails', groups: [:development, :test]
+gem 'whenever', require: false
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    chronic (0.10.2)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -202,6 +203,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -222,6 +225,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.1.3, >= 7.1.3.2)
   tzinfo-data
+  whenever
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,5 @@
+set :output, "log/cron.log"
+
+every 1.hour do
+  rake "call_rail:fetch_and_save_all"
+end

--- a/lib/tasks/fetch_call_data.rake
+++ b/lib/tasks/fetch_call_data.rake
@@ -12,8 +12,10 @@ namespace :call_rail do
         Rails.logger.info "Successful response for #{company_name}: #{response.body}"
 
         response.parsed_response["calls"].each do |call|
-          Rails.logger.info "Saving call with ID: #{call['id']} for Company ID: #{company_id}"
-          call_rail_datum = CallRailDatum.new(
+          Rails.logger.info "Processing call with ID: #{call['id']} for Company ID: #{company_id}"
+          call_rail_datum = CallRailDatum.find_or_initialize_by(call_id: call["id"])
+
+          call_rail_datum.assign_attributes(
             answered: call["answered"],
             business_phone_number: call["business_phone_number"],
             customer_city: call["customer_city"],
@@ -23,7 +25,6 @@ namespace :call_rail do
             customer_state: call["customer_state"],
             direction: call["direction"],
             duration: call["duration"],
-            call_id: call["id"],
             recording: call["recording"],
             recording_duration: call["recording_duration"],
             recording_player: call["recording_player"],


### PR DESCRIPTION
# Install Whenever gem and set rake to execute every hour

**Description:**
This PR sets up the `whenever` gem to automate the execution of a rake task that fetches and saves call data for all companies every hour. The changes include:

1. **Gemfile**: Added the `whenever` gem to manage cron jobs.
2. **Gemfile.lock**: Updated to include the `whenever` gem and its dependencies.
3. **config/schedule.rb**: Created a new schedule file to define the cron job that runs the rake task every hour.
4. **lib/tasks/fetch_call_data.rake**:
    - Modified to use `find_or_initialize_by` for fetching or initializing call data based on `call_id` to avoid duplication.
    - Removed the redundant `call_id` assignment since it is already used for finding or initializing the record.
    - Added more detailed logging for better traceability.

**Files Changed:**
1. **Gemfile**
2. **Gemfile.lock**
3. **config/schedule.rb**
4. **lib/tasks/fetch_call_data.rake**

**Commit:**
Install Whenever gem and set rake to execute every hour